### PR TITLE
ci: Update workflows for Docker build path and trigger method

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,10 +1,8 @@
 name: nuget
 
 on:
-  release:
-    types: [ published ] 
-    tags:
-      - v*
+  workflow_dispatch:
+  
 jobs:
   nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-ghcr.io.yml
+++ b/.github/workflows/publish-ghcr.io.yml
@@ -28,7 +28,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Build image
-        run: docker build --file ./src/6.0/Not.Again.Api.Host/Dockerfile --tag built-image ./src
+        run: docker build --file ./src/6.0/Not.Again.Api.Host/Dockerfile --tag built-image ./src/6.0
 
       - name: Push image
         run: |


### PR DESCRIPTION
Adjusted the Docker build context in the `publish-ghcr.io.yml` workflow to target the correct subdirectory. Also replaced the release-based trigger in `nuget.yml` with a manual `workflow_dispatch` trigger for better control.