### PR TITLE
feat: Add Docker Compose setup for Not.Again project

### DIFF
--- a/.compose/not-again/.env
+++ b/.compose/not-again/.env
@@ -1,0 +1,2 @@
+POSTGRES_PASSWORD = mysecretpassword
+RUNTIME_NETWORK = not-again-net

--- a/.compose/not-again/docker-compose.yml
+++ b/.compose/not-again/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+    postgres:
+        container_name: Not.Again.Postgres
+        image: postgres:13.22-trixie
+        ports:
+            - "5432:5432"      
+        environment:
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U postgres"]
+            interval: 5s
+            timeout: 5s
+            retries: 5
+        
+    not-again-api:
+        container_name: Not.Again.Api
+        image: ghcr.io/gman-au/not-again/not-again-api:latest
+        ports:
+            - "5000:5000"
+        depends_on:
+            postgres:
+                condition: service_healthy            
+        environment:
+            ConnectionStrings__NOT-AGAIN-SQL-POSTGRESQL: "Host=Not.Again.Postgres;Port=5432;Username=postgres;Password=${POSTGRES_PASSWORD};Database=not-again"
+            ASPNETCORE_URLS: "http://+:5000"
+            ASPNETCORE_ENVIRONMENT: "Development"
+        
+networks:
+    default:
+        name: ${RUNTIME_NETWORK}

--- a/src/6.0/Sample.NUnit.Test.Project/TestSettings.runsettings
+++ b/src/6.0/Sample.NUnit.Test.Project/TestSettings.runsettings
@@ -2,7 +2,7 @@
 <RunSettings>
     <RunConfiguration>
         <EnvironmentVariables>
-            <NOT_AGAIN_URL>http://localhost:5033</NOT_AGAIN_URL>
+            <NOT_AGAIN_URL>http://localhost:5000</NOT_AGAIN_URL>
             <RERUN_TESTS_OLDER_THAN_DAYS>20</RERUN_TESTS_OLDER_THAN_DAYS>
         </EnvironmentVariables>
     </RunConfiguration>


### PR DESCRIPTION
Introduce a Docker Compose configuration for Not.Again, including PostgreSQL and API services with a health check and network configuration. Update test project settings to align with the new API port.